### PR TITLE
Fix path to stylesheet

### DIFF
--- a/header.php
+++ b/header.php
@@ -10,7 +10,7 @@ function printheader()
         <title>TODO supply a title</title>
         <meta charset=\"UTF-8\">
         <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">");
-    print("<link rel=\"stylesheet\" type=\"text/css\" href=\"/styles/egstylesheet.css\">");
+    print("<link rel=\"stylesheet\" type=\"text/css\" href=\"styles/egstylesheet.css\">");
     print("</head>");
     print("<body>");
     printMenuBar("Menu Bars Are Cool!");


### PR DESCRIPTION
On LAMP using a / to indicate a relative directory does not work. I removed the / at the beggining of the path to the stylesheet in order to make it a relative directory. This may need to be changed to ./ if it doesn't work on WAMP.

Needs to be tested on WAMP before it is merged into master.